### PR TITLE
Updated dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please feel free to [pull requests](https://github.com/aikorea/awesome-rl/pulls)
  - [MATLAB Environment and GUI for Reinforcement Learning](http://www.cs.colostate.edu/~anderson/res/rl/matlabpaper/rl.html)
  - [Reinforcement Learning Repository - University of Massachusetts, Amherst](http://www-anw.cs.umass.edu/rlr/)
  - [Brown-UMBC Reinforcement Learning and Planning Library (Java)](http://burlap.cs.brown.edu/)
- - [Reinforcement Learning in R (MDP, Value Iteration)](http://www.statsblogs.com/2014/01/07/reinforcement-learning-in-r-markov-decision-process-mdp-and-value-iteration/)
+ - [Reinforcement Learning in R (MDP, Value Iteration)](http://www.moneyscience.com/pg/blog/StatAlgo/read/635759/reinforcement-learning-in-r-markov-decision-process-mdp-and-value-iteration)
  - [Reinforcement Learning Environment in Python and MATLAB](https://jamh-web.appspot.com/download.htm)
  - [RL-Glue](http://glue.rl-community.org/wiki/Main_Page) (standard interface for RL) and [RL-Glue Library](http://library.rl-community.org/wiki/Main_Page)
  - [PyBrain Library](http://www.pybrain.org/) - Python-Based Reinforcement learning, Artificial intelligence, and Neural network


### PR DESCRIPTION
So, neither the removed link nor the original (http://www.statalgo.com/2014/01/06/reinforcement-learning-in-r-markov-decision-process-mdp-and-value-iteration/) seem to work, though Internet Archive still has a copy: https://web.archive.org/web/20150526022159/http://www.statsblogs.com/2014/01/07/reinforcement-learning-in-r-markov-decision-process-mdp-and-value-iteration

The new link works for now but seems to have just aggregated one of the pages that was down.