### PR TITLE
Add Atari code repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Please feel free to [pull requests](https://github.com/aikorea/awesome-rl/pulls)
  - [PIQLE](http://sourceforge.net/projects/piqle/) - Platform Implementing Q-LEarning and other RL algorithms
  - [BeliefBox](https://code.google.com/p/beliefbox/) - Bayesian reinforcement learning library and toolkit
  - [Deep Q-Learning with Tensor Flow](https://github.com/nivwusquorum/tensorflow-deepq) - A deep Q learning demonstration using Google Tensorflow
+ - [Atari](https://github.com/Kaixhin/Atari) - Deep Q-networks and asynchronous agents in Torch
 
 ## Theory
 


### PR DESCRIPTION
Adding this repo as it not only contains the DQN and A3C but also other DQN advancements such as recurrent versions and the dueling network architecture.