### PR TITLE
Add RLCode/reinforcement-learning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please feel free to [pull requests](https://github.com/aikorea/awesome-rl/pulls)
  - [Deep Q-Learning with Tensor Flow](https://github.com/nivwusquorum/tensorflow-deepq) - A deep Q learning demonstration using Google Tensorflow
  - [Atari](https://github.com/Kaixhin/Atari) - Deep Q-networks and asynchronous agents in Torch
  - [AgentNet](https://github.com/yandexdataschool/AgentNet) - A python library for deep reinforcement learning and custom recurrent networks using Theano+Lasagne.
+ - [Reinforcement Learning Examples by RLCode](https://github.com/rlcode/reinforcement-learning) - A Collection of minimal and clean reinforcement learning examples
 
 ## Theory
 


### PR DESCRIPTION
Hello,
I wish to add a repo dedicated to reinforcement learning examples.
You can preview it [here](https://github.com/rlcode/reinforcement-learning).
Thanks,
Keon