### PR TITLE
Adds the MAgent multi-agent RL platform link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,4 @@ Computer Games
 - [OpenAI lab](https://github.com/kengz/openai_lab) - An experimentation system for Reinforcement Learning using OpenAI Gym, Tensorflow, and Keras.
 - [keras-rl](https://github.com/matthiasplappert/keras-rl) - State-of-the art deep reinforcement learning algorithms in Keras designed for compatibility with OpenAI.
 - [BURLAP](http://burlap.cs.brown.edu) - Brown-UMBC Reinforcement Learning and Planning, a library written in Java
+- [MAgent](https://github.com/geek-ai/MAgent) - A Platform for Many-agent Reinforcement Learning. 


### PR DESCRIPTION
This pull request adds the new multi-agent reinforcement learning platform _MAgent_ to the **Open Source Reinforcement Learning Platforms** section. 