### PR TITLE
Added DeepMind's TRFL to list of open source libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Computer Games
 - [TorchCraft](https://github.com/TorchCraft/TorchCraft) - Connecting Torch to StarCraft
 - [rllab](https://github.com/openai/rllab) - A framework for developing and evaluating reinforcement learning algorithms, fully compatible with OpenAI Gym
 - [TensorForce](https://github.com/reinforceio/tensorforce) - Practical deep reinforcement learning on TensorFlow with Gitter support and OpenAI Gym/Universe/DeepMind Lab integration.
+- [tf-TRFL](https://github.com/deepmind/trfl/) - A library built on top of TensorFlow that exposes several useful building blocks for implementing Reinforcement Learning agents.
 - [OpenAI lab](https://github.com/kengz/openai_lab) - An experimentation system for Reinforcement Learning using OpenAI Gym, Tensorflow, and Keras.
 - [keras-rl](https://github.com/matthiasplappert/keras-rl) - State-of-the art deep reinforcement learning algorithms in Keras designed for compatibility with OpenAI.
 - [BURLAP](http://burlap.cs.brown.edu) - Brown-UMBC Reinforcement Learning and Planning, a library written in Java


### PR DESCRIPTION
Recently DeepMind open sourced a new library for RL building blocks, more information here:

-  https://deepmind.com/blog/trfl/
- https://github.com/deepmind/trfl/blob/master/docs/index.md