### PR TITLE
Replace rllab with garage

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Computer Games
 - [torch-twrl](https://github.com/twitter/torch-twrl) - A package that enables reinforcement learning in Torch by Twitter
 - [UETorch](https://github.com/facebook/UETorch) - A Torch plugin for Unreal Engine 4 by Facebook
 - [TorchCraft](https://github.com/TorchCraft/TorchCraft) - Connecting Torch to StarCraft
-- [rllab](https://github.com/openai/rllab) - A framework for developing and evaluating reinforcement learning algorithms, fully compatible with OpenAI Gym
+- [garage](https://github.com/rlworkgroup/garage) - A framework for reproducible reinformcement learning research, fully compatible with OpenAI Gym and DeepMind Control Suite (successor to rllab)
 - [TensorForce](https://github.com/reinforceio/tensorforce) - Practical deep reinforcement learning on TensorFlow with Gitter support and OpenAI Gym/Universe/DeepMind Lab integration.
 - [tf-TRFL](https://github.com/deepmind/trfl/) - A library built on top of TensorFlow that exposes several useful building blocks for implementing Reinforcement Learning agents.
 - [OpenAI lab](https://github.com/kengz/openai_lab) - An experimentation system for Reinforcement Learning using OpenAI Gym, Tensorflow, and Keras.


### PR DESCRIPTION
rllab has been adopted by a coalition of researchers and open source contributors, and its successor project is called `garage`.

See the [announcement](https://github.com/rll/rllab/blob/master/README.md) by Rocky Duan on the original rllab repository, handing over maintenance of rllab to @rlworkgroup