### PR TITLE
Add (DeepMind x UCL) Reinforcement Learning Lecture Series 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Please feel free to [pull requests](https://github.com/aikorea/awesome-rl/pulls)
 ## Theory
 
 ### Lectures
+- [DeepMind x UCL] [Reinforcement Learning Lecture Series 2021](https://deepmind.com/learning-resources/reinforcement-learning-series-2021)
  - [UCL] [COMPM050/COMPGI13 Reinforcement Learning](http://www0.cs.ucl.ac.uk/staff/d.silver/web/Teaching.html) by David Silver
  - [UC Berkeley] CS188 Artificial Intelligence by Pieter Abbeel
    - [Lecture 8: Markov Decision Processes 1](https://www.youtube.com/watch?v=i0o-ui1N35U)


### PR DESCRIPTION
New RL course from Google DeepMind and University College London (UCL)