### PR TITLE
Add RL in poker games

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Traditional Games
   - Backgammon - Gerald Tesauro, "TD-Gammon" game play using TD(λ) (ACM 1995) [[Paper]](http://www.bkgm.com/articles/tesauro/tdl.html)
   - Chess - Jonathan Baxter, Andrew Tridgell and Lex Weaver, "KnightCap" program using TD(λ) (1999) [[arXiv]](http://arxiv.org/pdf/cs/9901002v1.pdf)
   - Chess - Matthew Lai, Giraffe: Using deep reinforcement learning to play chess (2015) [[arXiv]](http://arxiv.org/pdf/1509.01549v2.pdf)
+  - DouDizhu (poker) DouZero: Mastering DouDizhu with Self-Play Deep Reinforcement Learning (2021) [[arXiv]](https://arxiv.org/pdf/2106.06135.pdf)
 
 Computer Games
   - Atari 2600 Games - Volodymyr Mnih, Koray Kavukcuoglu, David Silver et al., Human-level Control through Deep Reinforcement Learning (Nature 2015) [[DOI]](https://dx.doi.org/doi:10.1038/nature14236) [[Paper]](http://www.readcube.com/articles/10.1038%2Fnature14236?shared_access_token=Lo_2hFdW4MuqEcF3CVBZm9RgN0jAjWel9jnR3ZoTv0P5kedCCNjz3FJ2FhQCgXkApOr3ZSsJAldp-tw3IWgTseRnLpAc9xQq-vTA2Z5Ji9lg16_WvCy4SaOgpK5XXA6ecqo8d8J7l4EJsdjwai53GqKt-7JuioG0r3iV67MQIro74l6IxvmcVNKBgOwiMGi8U0izJStLpmQp6Vmi_8Lw_A%3D%3D) [[Code]](https://sites.google.com/a/deepmind.com/dqn/) [[Video]](https://www.youtube.com/watch?v=iqXKQf2BOSE)
@@ -270,7 +271,7 @@ Computer Games
  - [Deep Q-Learning Demo](http://cs.stanford.edu/people/karpathy/convnetjs/demo/rldemo.html) - A deep Q learning demonstration using ConvNetJS
  - [Deep Q-Learning with Tensor Flow](https://github.com/nivwusquorum/tensorflow-deepq) - A deep Q learning demonstration using Google Tensorflow
  - [Reinforcement Learning Demo](http://cs.stanford.edu/people/karpathy/reinforcejs/) - A reinforcement learning demo using reinforcejs by Andrej Karpathy
-
+ - [DouDizhu Demo (Poker Game)](https://douzero.org/) - A reinforcement learning demo in Chinese poker DouDizhu
 
 ## Open Source Reinforcement Learning Platforms
 - [OpenAI gym](https://github.com/openai/gym) - A toolkit for developing and comparing reinforcement learning algorithms
@@ -296,6 +297,7 @@ Computer Games
 - [Microsoft AirSim](https://microsoft.github.io/AirSim/reinforcement_learning/) - Open source simulator based on Unreal Engine for autonomous vehicles from Microsoft AI & Research.
 - [DI-engine](https://github.com/opendilab/DI-engine) - DI-engine is a generalized Decision Intelligence engine. It supports most basic deep reinforcement learning (DRL) algorithms, such as DQN, PPO, SAC, and domain-specific algorithms like QMIX in multi-agent RL, GAIL in inverse RL, and RND in exploration problems.
 - [Jumanji](https://github.com/instadeepai/jumanji) - A Suite of Industry-Driven Hardware-Accelerated RL Environments written in JAX.
+- [RLCard](https://github.com/datamllab/rlcard/) - A toolkit for reinforcement learning in card games.
 
 ## valuable Contributors👩‍💻👨‍💻 :
 


### PR DESCRIPTION
I have added three items:

1. DouZero: Mastering DouDizhu with Self-Play Deep Reinforcement Learning is an application of reinforcement learning in DouDizhu game (the most popular poker game in China)
2. DouDizhu demo. https://douzero.org/ This is a nice demo where users can play against RL agents.
3. RLCard is a toolkit (platform) for reinforcement learning in card games. It supports multiple card environments, where users can train agents on it.